### PR TITLE
Fix new_confirmed_transactions args

### DIFF
--- a/tests/unit/block/test_utils.py
+++ b/tests/unit/block/test_utils.py
@@ -132,7 +132,7 @@ def test_confirm_blocks_new_block(
     assert transaction_single_bitcoin_address_one.is_confirmed is True
     mock_new_confirmed_transactions.assert_called_once_with(
         "transaction.tasks.new_confirmed_transactions",
-        [transaction_single_bitcoin_address_one.id],
+        ([transaction_single_bitcoin_address_one.id],),
     )
 
     address_output = Address.objects.get(hash="17opNHjQAqBheBubbxRgRQAPrmR6ePsB8k")

--- a/transaction/utils.py
+++ b/transaction/utils.py
@@ -203,5 +203,5 @@ def confirm_transactions(transactions):
             transaction.is_confirmed = True
             transaction.save(update_fields=["is_confirmed"])
     celery_app.send_task(
-        "transaction.tasks.new_confirmed_transactions", (transaction_ids)
+        "transaction.tasks.new_confirmed_transactions", (transaction_ids,)
     )


### PR DESCRIPTION
new_confirmed_transactions was receiving int instead of list of ints

```python
TypeError
'int' object is not iterable
```